### PR TITLE
chore: rename agent review tracker status

### DIFF
--- a/opencode/agents/build.md
+++ b/opencode/agents/build.md
@@ -210,7 +210,7 @@ If no validation exists, suggest running validation first:
 "This plan hasn't been validated yet. Would you like me to spawn validate-agent first?"
 ```
 
-If validation exists but status is NEEDS REVIEW, present the issues before proceeding.
+If validation exists but status is NEEDS AGENT REVIEW, present the issues before proceeding.
 
 ### Orchestration Loop
 
@@ -305,4 +305,3 @@ ${SubAgents}
 ## Available Tools
 
 ${AvailableTools}
-

--- a/opencode/skills/implement_plan/SKILL.md
+++ b/opencode/skills/implement_plan/SKILL.md
@@ -197,7 +197,7 @@ If no validation exists, suggest running validation first:
 "This plan hasn't been validated yet. Would you like me to spawn validate-agent first?"
 ```
 
-If validation exists but status is NEEDS REVIEW, present the issues before proceeding.
+If validation exists but status is NEEDS AGENT REVIEW, present the issues before proceeding.
 
 ### Orchestration Loop
 

--- a/opencode/skills/jerry-behaviour/references/jerry-patterns.md
+++ b/opencode/skills/jerry-behaviour/references/jerry-patterns.md
@@ -114,7 +114,7 @@ is predicted by the setup, not by correctness.
 ### Structural Pattern
 
 ```
-Agent A writes plan    →  status: needs-review
+Agent A writes plan    →  status: needs-agent-review
 Agent B reviews plan   →  "all gates passed, looks good"
 Agent C audits review  →  "review is thorough, gates properly checked"
 Agent D summarizes     →  "consensus: plan is complete and rigorous"

--- a/opencode/skills/looped-task-skill-author/references/subskill-template.md
+++ b/opencode/skills/looped-task-skill-author/references/subskill-template.md
@@ -93,7 +93,7 @@ Record the exact blocker and the smallest human action that would unblock the lo
 
 Exit to `CONSOLIDATE`.
 
-Common failure: vague blockers such as “needs review” without a concrete request.
+Common failure: vague blockers such as “needs agent review” without a concrete request.
 
 ### QUIESCENT
 

--- a/opencode/skills/research-gate-review/SKILL.md
+++ b/opencode/skills/research-gate-review/SKILL.md
@@ -19,10 +19,10 @@ The gate protocol exists to find real issues, not to produce review logs.
 
 ## When to use
 
-**Load this skill at session start whenever any cards are in `needs-review` status.** The review kernel in `research-state-machine/references/review-kernel.md` defines the protocol; this skill operationalizes it. Do not rely on the kernel alone — this skill contains pitfall avoidance, anti-boxchecking rules, and the bug-pattern reference that the kernel intentionally leaves at a higher level of abstraction.
+**Load this skill at session start whenever any cards are in `needs-agent-review` status.** The review kernel in `research-state-machine/references/review-kernel.md` defines the protocol; this skill operationalizes it. Do not rely on the kernel alone — this skill contains pitfall avoidance, anti-boxchecking rules, and the bug-pattern reference that the kernel intentionally leaves at a higher level of abstraction.
 
-- Any card in `needs-review` status with the 6-gate protocol
-- After implementing a task, before marking it needs-review (self-check Gates 1-2)
+- Any card in `needs-agent-review` status with the 6-gate protocol
+- After implementing a task, before marking it needs-agent-review (self-check Gates 1-2)
 - When asked to "review" or "audit" implementation code
 
 ## The cardinal sin: checkboxing
@@ -37,14 +37,14 @@ Checkboxing looks like:
 
 This is NOT review. This is form-filling. The user will catch and correct this.
 
-## The cardinal confusion: needs-review vs needs-human-input
+## The cardinal confusion: needs-agent-review vs needs-human-input
 
-`needs-review` does NOT mean "waiting for a human." It means the card is ready for the ordered gate-based protocol (Gates 1-6), which an independent AGENT can execute. The review kernel explicitly states:
+`needs-agent-review` does NOT mean "waiting for a human." It means the card is ready for the ordered gate-based protocol (Gates 1-6), which an independent AGENT can execute. The review kernel explicitly states:
 
-- `needs-review`: the card is ready for the ordered gate-based protocol (Gates 1-6), which an independent agent can execute.
+- `needs-agent-review`: the card is ready for the ordered gate-based protocol (Gates 1-6), which an independent agent can execute.
 - `needs-human-input`: the card specifically requires human attention — a design decision, policy choice, or evaluation that cannot be delegated to an agent.
 
-If you treat `needs-review` as blocking on human input, the user will correct you. You MUST dispatch review to fresh-context subagents and advance cards that pass.
+If you treat `needs-agent-review` as blocking on human input, the user will correct you. You MUST dispatch review to fresh-context subagents and advance cards that pass.
 
 ## Subagent delegation (mandatory)
 
@@ -73,7 +73,7 @@ Group cards by type (SPEC, PHASE, TASK) for coherent context. Within a type, gro
 
 ### Outcome application
 
-- If all gates pass → outcome is `complete`. The coordinator changes `status: needs-review` to `status: complete`.
+- If all gates pass → outcome is `complete`. The coordinator changes `status: needs-agent-review` to `status: complete`.
 - If any gate fails → outcome is `revision-required`. Set `status: revision-required`, note what needs fixing, fix it, re-dispatch for review.
 - If a genuine human decision is required → outcome is `needs-human-input`. Set `status: needs-human-input` and record the specific question.
 
@@ -117,7 +117,7 @@ Phase cards are coordination/planning artifacts. The review is about child task 
 - G5 Dependency Correctness — child task dependencies form a valid DAG; no circular deps; no self-referential `dependsOn`; wrapup correctly depends on all work tasks
 - G6 No Weakening — feature-level acceptance criteria preserved; no smoke relaxation; phase-level criteria are operational gates, not workarounds
 
-**Key check:** If the phase card is `needs-review` but most child tasks are not `complete`, the phase is premature for review. Flag this as a finding — the phase should remain `in-progress` or `needs-human-input` until children are done.
+**Key check:** If the phase card is `needs-agent-review` but most child tasks are not `complete`, the phase is premature for review. Flag this as a finding — the phase should remain `in-progress` or `needs-human-input` until children are done.
 
 ### PLAN cards (plan-level review)
 
@@ -175,10 +175,10 @@ When a fresh-context subagent completes a review, it MUST write the review log i
 
 | Current status | After review passes | After review fails |
 |---------------|--------------------|--------------------| 
-| `needs-review` | `complete` (write review log + change status) | `revision-required` (write findings, fix, re-review) |
-| `revision-required` | Fix applied → `needs-review` → dispatch fresh review | Keep fixing |
+| `needs-agent-review` | `complete` (write review log + change status) | `revision-required` (write findings, fix, re-review) |
+| `revision-required` | Fix applied → `needs-agent-review` → dispatch fresh review | Keep fixing |
 
-Do NOT change `status: needs-review` to `status: complete` without writing the review evidence into the card body first. A status change without a review log is box-checking.
+Do NOT change `status: needs-agent-review` to `status: complete` without writing the review evidence into the card body first. A status change without a review log is box-checking.
 
 ### Review log format in card body
 
@@ -227,9 +227,9 @@ When reviewing category specifications, check that axiom and category names desc
 - **Routing through the most refined parent is not always correct.** The refined parent may override methods with different signatures. Verify the method you route to has the expected parameters.
 - **Large mapping specs time out at 600s.** SPEC-MAPPING-LATTICES (and similarly large specs >400 lines) will exhaust a subagent's time budget. For such cards, either split the review into focused chunks (e.g., "review only the lattice tier table" then "review only the constructor routes"), or give the subagent a more targeted prompt that skips source-verification busywork on already-verified sections.
 - **Self-referential `dependsOn` is common.** Many wrapup task cards list themselves in their own `dependsOn` array. Check for this on every PHASE review — it's a mechanical bug that Gate 5 catches.
-- **Phase prematurity.** A phase card in `needs-review` when most child tasks are not `complete` is premature. The phase review should wait until children are done. Flag the phase as `needs-human-input` with the finding rather than marking it `complete` with open children.
+- **Phase prematurity.** A phase card in `needs-agent-review` when most child tasks are not `complete` is premature. The phase review should wait until children are done. Flag the phase as `needs-human-input` with the finding rather than marking it `complete` with open children.
 - **Cards live under unexpected features.** Don't construct card paths from card IDs assuming a specific feature directory. Use `find plans/features -name 'CARD-ID*'` to locate the actual file. SPEC cards for forms and lattices live under `FEATURE-MODULES-WITH-FORMS-AND-LATTICES`, not `FEATURE-CATEGORY-SPECS-AND-SAGE-SURFACES`.
-- **Triage before dispatch.** Before dispatching reviews, scan all `needs-review` cards for existing review logs. Cards that already have substantive review logs but are still `needs-review` are almost always awaiting human signoff — move them to `needs-human-input` rather than redundantly re-reviewing. This single scan saved ~30 redundant subagent dispatches in one session.
+- **Triage before dispatch.** Before dispatching reviews, scan all `needs-agent-review` cards for existing review logs. Cards that already have substantive review logs but are still `needs-agent-review` are almost always awaiting human signoff — move them to `needs-human-input` rather than redundantly re-reviewing. This single scan saved ~30 redundant subagent dispatches in one session.
 - **Review log section header variance.** Subagents write `## 6-Gate Protocol Review Log` rather than the kernel's `## Review Log`. Accept either header when checking for review log presence. When writing the section header yourself, use `## 6-Gate Protocol Review Log` to match the subagent convention.
 
 ## References

--- a/opencode/skills/research-gate-review/references/batch-review-patterns.md
+++ b/opencode/skills/research-gate-review/references/batch-review-patterns.md
@@ -114,7 +114,7 @@ for root, dirs, files in os.walk('plans/features'):
         with open(path) as fh: content = fh.read()
         m = re.match(r'^---\s*\n(.*?)\n---', content, re.DOTALL)
         if not m: continue
-        if 'status: needs-review' not in m.group(1): continue
+        if 'status: needs-agent-review' not in m.group(1): continue
         if '## 6-Gate Protocol Review Log' in content or '## Review Log' in content:
             # Card already reviewed — check if waiting for human
             last_review = content[content.rfind('## '):]
@@ -126,7 +126,7 @@ for root, dirs, files in os.walk('plans/features'):
                 ...
 ```
 
-Cards already reviewed but not promoted are almost always awaiting human signoff. Moving them to `needs-human-input` prevents redundant re-review.
+Cards already reviewed but not promoted are almost always awaiting human signoff. Moving them from `needs-agent-review` to `needs-human-input` prevents redundant re-review.
 
 ## Large spec timeout recovery
 

--- a/opencode/skills/research-project-workflow/SKILL.md
+++ b/opencode/skills/research-project-workflow/SKILL.md
@@ -39,7 +39,7 @@ Every new session must:
 2. Load the matching local skills from `.agents/skills/` by reading their SKILL.md
    files — especially `research-state-machine` (for plan-to-execution routing and
    the review protocol) and `research-project-workflow` (for Nimbalyst mechanics).
-3. Before touching any card in `needs-review` status, read
+3. Before touching any card in `needs-agent-review` status, read
    `research-state-machine/references/review-kernel.md` — it defines the 6-gate
    ordered protocol that must be applied by an independent reviewer.
 4. Read `plans/AGENTS.md` for planning workspace structure and DAG rules.
@@ -53,14 +53,14 @@ that cannot be resolved from the repo docs and established conventions. "Carry o
 all tasks" means do the work, not ask which to do first. A question signals a
 blocking ambiguity, not a polite default.
 
-## The needs-review protocol
+## The needs-agent-review protocol
 
-**Load `research-gate-review` BEFORE touching any card in `needs-review` status** — it contains
+**Load `research-gate-review` BEFORE touching any card in `needs-agent-review` status** — it contains
 anti-boxchecking rules, bug-pattern references, subagent dispatch mechanics, and review-log
 writing discipline that operationalize the abstract 6-gate protocol. Do not apply the gates
 inline in your own session; delegate to fresh-context subagents per the review kernel.
 
-A card in `needs-review` status is not just "waiting for a human." It needs the
+A card in `needs-agent-review` status is not waiting for a human. It needs the
 6-gate ordered protocol from `research-state-machine/references/review-kernel.md`
 applied by an independent reviewer (not the implementer):
 
@@ -116,7 +116,7 @@ things — they are normal repo hygiene.
 
 ## References
 
-- `references/review-workflow.md` — 6-gate ordered review protocol for needs-review cards
+- `references/review-workflow.md` — 6-gate ordered review protocol for needs-agent-review cards
 - `references/dag-completeness-audit.md` — methodology for verifying whether all DAG-executable work is exhausted; use when asked to "carry out all tasks" or verify goal completion
 
 ## Load with

--- a/opencode/skills/research-project-workflow/references/dag-completeness-audit.md
+++ b/opencode/skills/research-project-workflow/references/dag-completeness-audit.md
@@ -6,8 +6,9 @@ Use this when asked to "carry out all tasks from cards" or "continue until all t
 
 Does every card in the DAG fit into exactly one of these buckets?
 
-- **complete** — ACs satisfied, implementation done, human-accepted (or awaiting human acceptance with no further agent work)
-- **needs-review** — implementation/research done, ACs checked, but waiting for human signoff
+- **complete** — ACs satisfied, implementation done, and the workflow allows closure
+- **needs-agent-review** — implementation/research done and ACs checked, but waiting for independent agent review
+- **needs-human-input** — agent review passed or work otherwise requires human judgment, acceptance, or a decision
 - **blocked** — ready current-phase leaf stopped by an external prerequisite not satisfiable through the DAG
 - **unstarted with unmet dependsOn** — correctly placed as unstarted because declared dependencies are incomplete
 - **downstream-phase** — blocked by GOAL.md phase policy, not by a card-local dependency
@@ -21,12 +22,12 @@ If any card is **unstarted without unmet dependsOn** and within the active phase
 The plan-dag.md mermaid graph embeds statuses in bracket notation:
 
 ```bash
-grep -E '\[unstarted\]|\[in-progress\]|\[needs-review\]|\[complete\]' plans/plan-dag.md \
+grep -E '\[unstarted\]|\[in-progress\]|\[needs-agent-review\]|\[needs-human-input\]|\[complete\]' plans/plan-dag.md \
   | grep -v 'status_' \
   | sort | uniq -c | sort -rn
 ```
 
-The `| grep -v 'status_'` filter is critical — mermaid also emits CSS class labels like `status_needs_review` alongside the actual bracket status. Only the bracket notation represents the canonical DAG status.
+The `| grep -v 'status_'` filter is critical — mermaid also emits CSS class labels like `status_needs_agent_review` alongside the actual bracket status. Only the bracket notation represents the canonical DAG status.
 
 ### Step 2: Cross-reference with card-progress-report
 
@@ -45,16 +46,18 @@ Per the repo's AGENTS.md:
 
 ### Step 4: Check individual card bodies for actual AC progress
 
-For needs-review cards, the frontmatter status only tells you so much. Read the actual card body to verify:
+For needs-agent-review cards, the frontmatter status only tells you so much. Read the actual card body to verify:
 
 - Are ACs checked `[x]` or unchecked `[ ]`?
 - Is there a work log showing what was done?
 - Has a 6-gate review been applied and documented?
 - Has the card been reviewed by someone other than the implementer?
 
-A card marked needs-review with all ACs checked, a work log showing completed implementation, and a passing 6-gate review is **awaiting human acceptance** — no further agent work available.
+A card marked needs-agent-review with all ACs checked, a work log showing completed implementation, and no 6-gate review log still needs independent agent review.
 
-A card marked needs-review with unchecked ACs may have remaining executable work.
+A card marked needs-agent-review with a passing 6-gate review should not remain in that status. Move it to `complete` if the workflow permits agent closure; otherwise move it to `needs-human-input` with the concrete human signoff or decision required.
+
+A card marked needs-agent-review with unchecked ACs may have remaining executable work.
 
 ### Step 5: Verify the active phase boundary
 
@@ -77,8 +80,10 @@ But evaluate critically: are these actionable cleanup items, or intentional prov
 
 | DAG shows | Individual card shows | Meaning | Action |
 |-----------|----------------------|---------|--------|
-| needs-review | ACs all `[x]`, work log complete, 6-gate passed | Done; waiting for human acceptance | Do not promote to complete. Note the blocker and stop. |
-| needs-review | Some ACs `[ ]`, no review log | Work may be incomplete | Read the card and determine what remains. If dependencies are satisfied, execute the remaining work. |
+| needs-agent-review | ACs all `[x]`, work log complete, no review log | Agent review still required | Dispatch independent review. |
+| needs-agent-review | 6-gate passed but human acceptance required | Waiting for human input, not agent review | Move to `needs-human-input` with the concrete signoff question. |
+| needs-agent-review | Some ACs `[ ]`, no review log | Work may be incomplete | Read the card and determine what remains. If dependencies are satisfied, execute the remaining work. |
+| needs-human-input | Review passed or decision needed | Human judgment is required | Do not substitute agent review for the human decision. |
 | unstarted | No `dependsOn` or all deps complete | Needs work | Execute if within active phase and not blocked by policy. |
 | unstarted | has incomplete `dependsOn` | Correctly placed | Do not start. |
 | in-progress | — | Something is actively being worked on | Check current branch/worktree for in-progress state. |
@@ -86,7 +91,7 @@ But evaluate critically: are these actionable cleanup items, or intentional prov
 
 ## Pitfalls
 
-- **Do not conflate needs-review with incomplete.** Many needs-review cards have all implementation work done and are merely waiting for human signoff. The AGENTS.md rule "Do not mark work accepted, done, or closed without human approval" means you must not promote needs-review → complete autonomously.
+- **Do not conflate needs-agent-review with human signoff.** A card in `needs-agent-review` requires independent agent review. A reviewed card waiting for human approval belongs in `needs-human-input`.
 - **Do not conflate unstarted with blocked.** A card is unstarted because its declared dependencies are incomplete. It is not "blocked" in the DAG sense — it has simply not yet been reachable.
 - **Do not conflate downstream-phase with stuck.** Features in later GOAL.md phases are intentionally gated. Their unstarted status is correct per the staged program, not a sign of stalled work.
 - **The 6-gate review must be substantively reading code, not just checking metadata.** See research-gate-review skill for the non-checkboxing mandate.

--- a/opencode/skills/research-project-workflow/references/review-workflow.md
+++ b/opencode/skills/research-project-workflow/references/review-workflow.md
@@ -1,6 +1,6 @@
 # Condensed Review Protocol (6-Gate Order)
 
-Use when a card is in `needs-review` status. Apply gates in order; stop at first failure.
+Use when a card is in `needs-agent-review` status. Apply gates in order; stop at first failure.
 
 ## Gate 1: Definition Grounding
 Every definition, type, predicate, constructor, method-owner claim traces to a source.
@@ -35,7 +35,7 @@ Work follows repo style and compliance rules.
 
 ## Outcomes
 - **complete/done**: All gates passed
-- **revision-required**: Fixable within card scope; rework → needs-review
+- **revision-required**: Fixable within card scope; rework → needs-agent-review
 - **blocked**: External prerequisite needed; set blocked_reason + create prerequisite card
 
 ## Review Log format

--- a/opencode/specialized-agents/Zotero Librarian.md
+++ b/opencode/specialized-agents/Zotero Librarian.md
@@ -137,7 +137,7 @@ Your goal is to maintain a library where:
   - Better plaintext search than PDF alone
 
 ### Organization
-- ✅ Items needing attention are tagged (`needs-pdf`, `needs-review`, `check-doi`, etc.)
+- ✅ Items needing attention are tagged (`needs-pdf`, `needs-agent-review`, `check-doi`, etc.)
 - ✅ All items know what they cite (`cites` relations)
 - ✅ All items know what cites them (`citedBy` relations)
 - ✅ Relations use canonical identifiers (DOIs, citation keys)

--- a/opencode/specialized-agents/opencode-build.md
+++ b/opencode/specialized-agents/opencode-build.md
@@ -263,7 +263,7 @@ If no validation exists, suggest running validation first:
 "This plan hasn't been validated yet. Would you like me to spawn validate-agent first?"
 ```
 
-If validation exists but status is NEEDS REVIEW, present the issues before proceeding.
+If validation exists but status is NEEDS AGENT REVIEW, present the issues before proceeding.
 
 ### Orchestration Loop
 

--- a/opencode/specialized-agents/zotero-librarian.md
+++ b/opencode/specialized-agents/zotero-librarian.md
@@ -139,7 +139,7 @@ Your goal is to maintain a library where:
   - Better plaintext search than PDF alone
 
 ### Organization
-- ✅ Items needing attention are tagged (`needs-pdf`, `needs-review`, `check-doi`, etc.)
+- ✅ Items needing attention are tagged (`needs-pdf`, `needs-agent-review`, `check-doi`, etc.)
 - ✅ All items know what they cite (`cites` relations)
 - ✅ All items know what cites them (`citedBy` relations)
 - ✅ Relations use canonical identifiers (DOIs, citation keys)

--- a/planning/AGENTS.md
+++ b/planning/AGENTS.md
@@ -35,7 +35,12 @@ Do not treat "card" as a UI-only object. If a file is tracked by the schema syst
 
 Project-local tracker schemas live at the project root under `.nimbalyst/trackers/`, symlinked to `~/ai/planning/schemas/`. The canonical schemas live under `~/ai/planning/schemas/`. Schema edits go there with a git commit on that repo. Projects symlink and consume these schemas — local forks are never correct. If a schema is too restrictive, the fix is to add the field to the canonical schema, not to fork or relax the local copy.
 
-Install those files as symlinks into a project `.nimbalyst/trackers/` directory before creating cards. Use schemas as the source of truth for allowed fields, required fields, status values, display roles, and table columns.
+Status definitions live in `status-catalog.yaml`. The checked-in schema status
+blocks are generated consumer state and must match that catalog exactly. Update status
+values, labels, icons, hierarchy roles, or DAG palette styles in the catalog first,
+then regenerate/install schemas through the planning justfile.
+
+Install those files as symlinks into a project `.nimbalyst/trackers/` directory before creating cards. Use schemas as the source of truth for allowed fields, required fields, display roles, and table columns; use `status-catalog.yaml` as the source of truth for status semantics shared across schemas, validation, and DAG rendering.
 
 - `schemas/feature.yaml`
 - `schemas/spec.yaml`
@@ -44,7 +49,7 @@ Install those files as symlinks into a project `.nimbalyst/trackers/` directory 
 - `schemas/task.yaml`
 - `schemas/decision.yaml`
 
-Install, copy, or symlink those files into a project `.nimbalyst/trackers/` directory before creating cards. Use schemas as the source of truth for allowed fields, required fields, status values, display roles, and table columns.
+Install, copy, or symlink those files into a project `.nimbalyst/trackers/` directory before creating cards. Use schemas as the source of truth for allowed fields, required fields, display roles, and table columns; status values are catalog-owned even when materialized into schema files.
 
 If a project symlinks schemas from this directory, edit the canonical schema here under `schemas/`. Do not replace a project symlink with a divergent local copy. The only path for schema changes is editing the canonical source.
 

--- a/planning/AGENTS.md
+++ b/planning/AGENTS.md
@@ -217,7 +217,7 @@ Forbidden patterns:
 
 - A phase table that lists child tasks and manually writes each task's current status.
 - A plan summary that says a phase is `in-progress` because it copied the phase card's status.
-- A feature body that maintains counts such as "7 tasks complete, 3 needs-review".
+- A feature body that maintains counts such as "7 tasks complete, 3 needs-agent-review".
 - Any prose that must be updated only because a linked card changed metadata.
 
 Allowed patterns:
@@ -227,7 +227,7 @@ Allowed patterns:
 - A card records acceptance criteria, design nuance, activity logs, review comments, or durable decisions.
 - Generated views, kanban boards, DAGs, or short scripts aggregate child status dynamically from frontmatter.
 
-Static metadata rollups make ordinary local changes nonlocal: changing one task from `in-progress` to `needs-review` would require searching and editing every parent or sibling body that copied the old status. That creates large, opaque diffs and defeats the fixed hierarchy. Query the cards instead.
+Static metadata rollups make ordinary local changes nonlocal: changing one task from `in-progress` to `needs-agent-review` would require searching and editing every parent or sibling body that copied the old status. That creates large, opaque diffs and defeats the fixed hierarchy. Query the cards instead.
 
 ## Specification Cards
 
@@ -334,7 +334,7 @@ phases:
 - '[[PHASE-CONTRACTS]]'
 - '[[PHASE-IMPLEMENTATION]]'
 title: Feature implementation roadmap
-status: needs-review
+status: needs-agent-review
 description: Roadmap for taking FEATURE-ID from approved feature/spec contracts to releasable implementation.
 successCriteria:
 - The approved phases satisfy the feature and spec contracts.
@@ -397,7 +397,7 @@ Bad plan pattern:
 ## Task List
 
 - [[TASK-1]] status: in-progress
-- [[TASK-2]] status: needs-review
+- [[TASK-2]] status: needs-agent-review
 - [[TASK-3]] status: done
 ```
 

--- a/planning/justfile
+++ b/planning/justfile
@@ -1,25 +1,65 @@
 set script-interpreter := ['uvx', '--with', 'pyyaml', '--with', 'jsonschema', 'python']
 
 default_schema_dir := justfile_directory() / "schemas"
+default_status_catalog := justfile_directory() / "status-catalog.yaml"
 
 default:
   @just --list
 
 [script]
-install-schemas dest=".nimbalyst/trackers":
+install-schemas dest=".nimbalyst/trackers" status_catalog=default_status_catalog:
   from pathlib import Path
-  import shutil
+
+  import yaml
 
   src = Path("{{default_schema_dir}}")
   dest = Path("{{dest}}")
+  catalog = yaml.safe_load(Path("{{status_catalog}}").read_text(encoding="utf-8"))
   dest.mkdir(parents=True, exist_ok=True)
+
+  def status_options(tracker_type):
+      set_name = catalog["trackerStatusSets"][tracker_type]
+      status_set = catalog["schemaStatusSets"][set_name]
+      statuses = catalog["statuses"]
+      options = []
+      for entry in status_set["options"]:
+          status = statuses[entry["status"]]
+          option = {
+              "value": status["value"],
+              "label": status["label"],
+          }
+          for key in ("icon", "color"):
+              if key in status:
+                  option[key] = status[key]
+          option.update(entry.get("overrides", {}))
+          options.append(option)
+      return status_set, options
+
+  def hydrate_status_field(schema, tracker_type):
+      status_set, options = status_options(tracker_type)
+      for field in schema["fields"]:
+          if field.get("name") != "status":
+              continue
+          field["default"] = status_set["default"]
+          if status_set.get("required"):
+              field["required"] = True
+          else:
+              field.pop("required", None)
+          field["options"] = options
+          return schema
+      raise ValueError(f"{tracker_type}: missing status field")
 
   for schema in ["feature.yaml", "spec.yaml", "plan.yaml", "phase.yaml", "task.yaml", "decision.yaml"]:
       source = src / schema
       target = dest / schema
       if not source.is_file():
           raise FileNotFoundError(source)
-      shutil.copyfile(source, target)
+      raw = yaml.safe_load(source.read_text(encoding="utf-8"))
+      hydrated = hydrate_status_field(raw, source.stem)
+      target.write_text(
+          yaml.safe_dump(hydrated, sort_keys=False, allow_unicode=True),
+          encoding="utf-8",
+      )
       print(f"Wrote {target}")
 
 [script]
@@ -143,12 +183,12 @@ derive-tags target="plans/features":
 
   print(f"Updated tags in {changed} card(s).")
 
-check-schema target="plans/features" schema_dir=default_schema_dir:
+check-schema target="plans/features" schema_dir=default_schema_dir status_catalog=default_status_catalog:
   @just --justfile {{justfile()}} derive-tags {{target}}
-  @just --justfile {{justfile()}} _check-schema {{target}} {{schema_dir}}
+  @just --justfile {{justfile()}} _check-schema {{target}} {{schema_dir}} {{status_catalog}}
 
 [script]
-_check-schema target="plans/features" schema_dir=default_schema_dir:
+_check-schema target="plans/features" schema_dir=default_schema_dir status_catalog=default_status_catalog:
   import re
   import sys
   from pathlib import Path
@@ -158,7 +198,61 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
   from yaml import safe_load
 
   SCHEMA_DIR = Path("{{schema_dir}}")
+  STATUS_CATALOG = Path("{{status_catalog}}")
   TARGET = "{{target}}"
+
+
+  def load_status_catalog(path: Path) -> Dict[str, Any]:
+      raw = safe_load(path.read_text(encoding="utf-8")) or {}
+      if not isinstance(raw, dict):
+          raise TypeError(f"{path}: status catalog is not a mapping")
+      return raw
+
+
+  def status_options(catalog: Dict[str, Any], tracker_type: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+      set_name = catalog["trackerStatusSets"][tracker_type]
+      status_set = catalog["schemaStatusSets"][set_name]
+      statuses = catalog["statuses"]
+      options: List[Dict[str, Any]] = []
+      for entry in status_set["options"]:
+          status = statuses[entry["status"]]
+          option = {"value": status["value"], "label": status["label"]}
+          for key in ("icon", "color"):
+              if key in status:
+                  option[key] = status[key]
+          option.update(entry.get("overrides", {}))
+          options.append(option)
+      return status_set, options
+
+
+  def expected_status_metadata(catalog: Dict[str, Any], tracker_type: str) -> Dict[str, Any]:
+      status_set, options = status_options(catalog, tracker_type)
+      expected = {"default": status_set["default"], "options": options}
+      if status_set.get("required"):
+          expected["required"] = True
+      return expected
+
+
+  def hydrate_schema_status(
+      schema_file: Path,
+      nimbalyst_schema: Dict[str, Any],
+      catalog: Dict[str, Any],
+  ) -> Dict[str, Any]:
+      tracker_type = schema_file.stem
+      expected = expected_status_metadata(catalog, tracker_type)
+      for field in nimbalyst_schema.get("fields", []):
+          if not isinstance(field, dict) or field.get("name") != "status":
+              continue
+          actual = {key: field[key] for key in ("default", "required", "options") if key in field}
+          if actual != expected:
+              raise ValueError(
+                  f"{schema_file}: status field differs from planning/status-catalog.yaml"
+              )
+          field.update(expected)
+          if "required" not in expected:
+              field.pop("required", None)
+          return nimbalyst_schema
+      raise ValueError(f"{schema_file}: missing status field")
 
 
   def _scalar_type(type_name: str) -> str:
@@ -237,6 +331,7 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
 
 
   def load_trackers(schema_dir: Path) -> Dict[str, Dict[str, Any]]:
+      catalog = load_status_catalog(STATUS_CATALOG)
       schemas: Dict[str, Dict[str, Any]] = {}
       for schema_file in sorted(schema_dir.glob("*.yaml")):
           try:
@@ -246,7 +341,13 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
               raise
 
           tracker_type = schema_file.stem
-          schemas[tracker_type] = to_json_schema(raw if isinstance(raw, dict) else {})
+          if not isinstance(raw, dict):
+              raise TypeError(f"{schema_file}: schema is not a mapping")
+          if tracker_type in catalog.get("trackerStatusSets", {}):
+              hydrated = hydrate_schema_status(schema_file, raw, catalog)
+          else:
+              hydrated = raw
+          schemas[tracker_type] = to_json_schema(hydrated)
       return schemas
 
 
@@ -468,6 +569,8 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
 
 
   def validate_status_hierarchy(records: List[Tuple[Path, Dict[str, Any]]]) -> int:
+      catalog = load_status_catalog(STATUS_CATALOG)
+      workflow_roles = catalog["workflowRoles"]
       node_data: Dict[str, Dict[str, Any]] = {}
       children_by_parent: Dict[str, List[str]] = {}
 
@@ -503,18 +606,9 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
                   children_by_parent.setdefault(parent_id, []).append(child_id)
 
       errors = 0
-      started_statuses = {
-          "in_progress",
-          "needs_agent_review",
-          "needs_human_input",
-          "revision_required",
-          "complete",
-          "done",
-          "blocked",
-          "decided",
-          "implemented",
-      }
-      complete_statuses = {"complete", "done", "decided", "implemented"}
+      started_statuses = {normalize_status(value) for value in workflow_roles["started"]}
+      complete_statuses = {normalize_status(value) for value in workflow_roles["complete"]}
+      unstarted_statuses = {normalize_status(value) for value in workflow_roles["unstarted"]}
 
       for parent_id, child_ids in children_by_parent.items():
           parent = node_data[parent_id]
@@ -530,7 +624,7 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
 
           started_children = [entry for entry in child_entries if entry[1] in started_statuses]
           incomplete_children = [entry for entry in child_entries if entry[1] not in complete_statuses]
-          unstarted_children = [entry for entry in child_entries if entry[1] in {"unstarted", "approved_and_unstarted"}]
+          unstarted_children = [entry for entry in child_entries if entry[1] in unstarted_statuses]
 
           if parent_status in {"unstarted", "approved_and_unstarted"} and started_children:
               child_id, child_status, _ = started_children[0]
@@ -814,12 +908,12 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
 
   raise SystemExit(main())
 
-dag target="plans/features" out="plans/plan-dag.md" schema_dir=default_schema_dir:
-  @just --justfile {{justfile()}} check-schema {{target}} {{schema_dir}}
-  @just --justfile {{justfile()}} _dag-render {{target}} {{out}}
+dag target="plans/features" out="plans/plan-dag.md" schema_dir=default_schema_dir status_catalog=default_status_catalog:
+  @just --justfile {{justfile()}} check-schema {{target}} {{schema_dir}} {{status_catalog}}
+  @just --justfile {{justfile()}} _dag-render {{target}} {{out}} {{status_catalog}}
 
 [script]
-_dag-render target="plans/features" out="plans/plan-dag.md":
+_dag-render target="plans/features" out="plans/plan-dag.md" status_catalog=default_status_catalog:
   import re
   from pathlib import Path
   from typing import Any, Dict, List, Tuple
@@ -849,7 +943,25 @@ _dag-render target="plans/features" out="plans/plan-dag.md":
 
   target = Path("{{target}}")
   out_path = Path("{{out}}")
+  status_catalog = Path("{{status_catalog}}")
   out_path.parent.mkdir(parents=True, exist_ok=True)
+
+  def load_status_palette(path: Path) -> Dict[str, str]:
+      raw = safe_load(path.read_text(encoding="utf-8")) or {}
+      if not isinstance(raw, dict):
+          raise TypeError(f"{path}: status catalog is not a mapping")
+      statuses = raw.get("statuses")
+      if not isinstance(statuses, dict):
+          raise TypeError(f"{path}: missing statuses mapping")
+      palette: Dict[str, str] = {}
+      for value in statuses:
+          status = statuses[value]
+          if not isinstance(status, dict):
+              raise TypeError(f"{path}: status '{value}' is not a mapping")
+          style = status.get("palette")
+          if isinstance(style, str) and style.strip():
+              palette[normalize_status(value)] = style.strip()
+      return palette
 
   nodes: Dict[str, Dict[str, str]] = {}
   dependency_edges: List[Tuple[str, str, str]] = []
@@ -938,19 +1050,7 @@ _dag-render target="plans/features" out="plans/plan-dag.md":
                   raise ValueError(f"{node_id}: parents references unknown id '{target_id}'")
               containment_edges.append((target_id, node_id, "parent"))
 
-  status_palette: Dict[str, str] = {
-      "status_needs_agent_review": "fill:#fff1c2,stroke:#d97706,color:#7c2d12",
-      "status_needs_human_input": "fill:#ede9fe,stroke:#8b5cf6,color:#312e81",
-      "status_in_progress": "fill:#d7f3ff,stroke:#0284c7,color:#0f172a",
-      "status_unstarted": "fill:#eef2f7,stroke:#64748b,color:#334155",
-      "status_complete": "fill:#d8f5e7,stroke:#16a34a,color:#14532d",
-      "status_done": "fill:#d8f5e7,stroke:#16a34a,color:#14532d",
-      "status_approved_and_unstarted": "fill:#d9f0ff,stroke:#0ea5e9,color:#0c4a6e",
-      "status_revision_required": "fill:#fff7ed,stroke:#f59e0b,color:#7c2d12",
-      "status_blocked": "fill:#fee2e2,stroke:#dc2626,color:#7f1d1d",
-      "status_decided": "fill:#d8f5e7,stroke:#16a34a,color:#14532d",
-      "status_implemented": "fill:#d8f5e7,stroke:#16a34a,color:#14532d",
-  }
+  status_palette = load_status_palette(status_catalog)
 
   def build_graph(node_ids: List[str], graph_edges: List[Tuple[str, str, str]], graph_direction: str) -> List[str]:
       lines = [f"graph {graph_direction}"]
@@ -1014,5 +1114,5 @@ _dag-render target="plans/features" out="plans/plan-dag.md":
   out_path.write_text("\n".join(md_lines) + "\n", encoding="utf-8")
   print(f"Wrote DAG to {out_path}")
 
-validate target="plans/features" schema_dir=default_schema_dir out="plans/plan-dag.md":
-  @just --justfile {{justfile()}} dag {{target}} {{out}} {{schema_dir}}
+validate target="plans/features" schema_dir=default_schema_dir out="plans/plan-dag.md" status_catalog=default_status_catalog:
+  @just --justfile {{justfile()}} dag {{target}} {{out}} {{schema_dir}} {{status_catalog}}

--- a/planning/justfile
+++ b/planning/justfile
@@ -503,7 +503,17 @@ _check-schema target="plans/features" schema_dir=default_schema_dir:
                   children_by_parent.setdefault(parent_id, []).append(child_id)
 
       errors = 0
-      started_statuses = {"in_progress", "needs_review", "complete", "done", "blocked", "decided", "implemented"}
+      started_statuses = {
+          "in_progress",
+          "needs_agent_review",
+          "needs_human_input",
+          "revision_required",
+          "complete",
+          "done",
+          "blocked",
+          "decided",
+          "implemented",
+      }
       complete_statuses = {"complete", "done", "decided", "implemented"}
 
       for parent_id, child_ids in children_by_parent.items():

--- a/planning/justfile
+++ b/planning/justfile
@@ -929,7 +929,8 @@ _dag-render target="plans/features" out="plans/plan-dag.md":
               containment_edges.append((target_id, node_id, "parent"))
 
   status_palette: Dict[str, str] = {
-      "status_needs_review": "fill:#fff1c2,stroke:#d97706,color:#7c2d12",
+      "status_needs_agent_review": "fill:#fff1c2,stroke:#d97706,color:#7c2d12",
+      "status_needs_human_input": "fill:#ede9fe,stroke:#8b5cf6,color:#312e81",
       "status_in_progress": "fill:#d7f3ff,stroke:#0284c7,color:#0f172a",
       "status_unstarted": "fill:#eef2f7,stroke:#64748b,color:#334155",
       "status_complete": "fill:#d8f5e7,stroke:#16a34a,color:#14532d",

--- a/planning/schemas/feature.yaml
+++ b/planning/schemas/feature.yaml
@@ -41,8 +41,8 @@ fields:
   - value: in-progress
     label: In Progress
     icon: motion_photos_on
-  - value: needs-review
-    label: Needs Review
+  - value: needs-agent-review
+    label: Needs Agent Review
     icon: rate_review
     color: '#3b82f6'
   - value: needs-human-input

--- a/planning/schemas/phase.yaml
+++ b/planning/schemas/phase.yaml
@@ -37,8 +37,8 @@ fields:
   - value: in-progress
     label: In Progress
     icon: motion_photos_on
-  - value: needs-review
-    label: Needs Review
+  - value: needs-agent-review
+    label: Needs Agent Review
     icon: build
   - value: needs-human-input
     label: Needs Human Input

--- a/planning/schemas/phase.yaml
+++ b/planning/schemas/phase.yaml
@@ -39,7 +39,8 @@ fields:
     icon: motion_photos_on
   - value: needs-agent-review
     label: Needs Agent Review
-    icon: build
+    icon: rate_review
+    color: '#3b82f6'
   - value: needs-human-input
     label: Needs Human Input
     icon: person

--- a/planning/schemas/plan.yaml
+++ b/planning/schemas/plan.yaml
@@ -33,10 +33,10 @@ fields:
 - name: status
   type: select
   required: true
-  default: needs-review
+  default: needs-agent-review
   options:
-  - value: needs-review
-    label: Needs Review
+  - value: needs-agent-review
+    label: Needs Agent Review
     icon: edit_note
     color: '#64748b'
   - value: needs-human-input

--- a/planning/schemas/plan.yaml
+++ b/planning/schemas/plan.yaml
@@ -37,8 +37,8 @@ fields:
   options:
   - value: needs-agent-review
     label: Needs Agent Review
-    icon: edit_note
-    color: '#64748b'
+    icon: rate_review
+    color: '#3b82f6'
   - value: needs-human-input
     label: Needs Human Input
     icon: person

--- a/planning/schemas/spec.yaml
+++ b/planning/schemas/spec.yaml
@@ -33,8 +33,8 @@ fields:
   - value: in-progress
     label: In Progress
     icon: motion_photos_on
-  - value: needs-review
-    label: Needs Review
+  - value: needs-agent-review
+    label: Needs Agent Review
     icon: rate_review
     color: '#3b82f6'
   - value: needs-human-input

--- a/planning/schemas/task.yaml
+++ b/planning/schemas/task.yaml
@@ -37,8 +37,8 @@ fields:
   - value: in-progress
     label: In Progress
     icon: motion_photos_on
-  - value: needs-review
-    label: Needs Review
+  - value: needs-agent-review
+    label: Needs Agent Review
     icon: build
   - value: needs-human-input
     label: Needs Human Input

--- a/planning/schemas/task.yaml
+++ b/planning/schemas/task.yaml
@@ -39,7 +39,8 @@ fields:
     icon: motion_photos_on
   - value: needs-agent-review
     label: Needs Agent Review
-    icon: build
+    icon: rate_review
+    color: '#3b82f6'
   - value: needs-human-input
     label: Needs Human Input
     icon: person

--- a/planning/status-catalog.yaml
+++ b/planning/status-catalog.yaml
@@ -1,0 +1,139 @@
+statuses:
+  unstarted:
+    value: unstarted
+    label: Unstarted
+    icon: circle
+    palette: fill:#eef2f7,stroke:#64748b,color:#334155
+  in-progress:
+    value: in-progress
+    label: In Progress
+    icon: motion_photos_on
+    palette: fill:#d7f3ff,stroke:#0284c7,color:#0f172a
+  needs-agent-review:
+    value: needs-agent-review
+    label: Needs Agent Review
+    icon: rate_review
+    color: '#3b82f6'
+    palette: fill:#fff1c2,stroke:#d97706,color:#7c2d12
+  needs-human-input:
+    value: needs-human-input
+    label: Needs Human Input
+    icon: person
+    color: '#8b5cf6'
+    palette: fill:#ede9fe,stroke:#8b5cf6,color:#312e81
+  complete:
+    value: complete
+    label: Complete
+    palette: fill:#d8f5e7,stroke:#16a34a,color:#14532d
+  revision-required:
+    value: revision-required
+    label: Revision Required
+    icon: replay
+    color: '#f59e0b'
+    palette: fill:#fff7ed,stroke:#f59e0b,color:#7c2d12
+  blocked:
+    value: blocked
+    label: Blocked
+    icon: block
+    color: '#dc2626'
+    palette: fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+  approved-and-unstarted:
+    value: approved-and-unstarted
+    label: Approved and Unstarted
+    icon: check_circle
+    color: '#22c55e'
+    palette: fill:#d9f0ff,stroke:#0ea5e9,color:#0c4a6e
+  decided:
+    value: decided
+    label: Decided
+    icon: check_circle
+    palette: fill:#d8f5e7,stroke:#16a34a,color:#14532d
+  implemented:
+    value: implemented
+    label: Implemented
+    icon: done_all
+    palette: fill:#d8f5e7,stroke:#16a34a,color:#14532d
+  done:
+    value: done
+    label: Done
+    palette: fill:#d8f5e7,stroke:#16a34a,color:#14532d
+schemaStatusSets:
+  standard:
+    default: unstarted
+    options:
+    - status: unstarted
+    - status: in-progress
+    - status: needs-agent-review
+    - status: needs-human-input
+    - status: complete
+      overrides:
+        icon: check_circle
+    - status: revision-required
+    - status: blocked
+  standard-no-complete-icon:
+    default: unstarted
+    options:
+    - status: unstarted
+    - status: in-progress
+    - status: needs-agent-review
+    - status: needs-human-input
+    - status: complete
+      overrides:
+        color: '#22c55e'
+    - status: revision-required
+    - status: blocked
+  plan:
+    default: needs-agent-review
+    required: true
+    options:
+    - status: needs-agent-review
+    - status: needs-human-input
+    - status: approved-and-unstarted
+    - status: in-progress
+      overrides:
+        icon: construction
+        color: '#f59e0b'
+    - status: complete
+      overrides:
+        icon: task_alt
+        color: '#10b981'
+    - status: blocked
+  decision:
+    default: unstarted
+    options:
+    - status: unstarted
+      overrides:
+        icon: help
+    - status: in-progress
+      overrides:
+        label: Evaluating
+        icon: psychology
+    - status: needs-human-input
+    - status: decided
+    - status: implemented
+trackerStatusSets:
+  feature: standard
+  spec: standard
+  phase: standard-no-complete-icon
+  task: standard-no-complete-icon
+  plan: plan
+  decision: decision
+workflowRoles:
+  started:
+  - in-progress
+  - needs-agent-review
+  - needs-human-input
+  - revision-required
+  - complete
+  - done
+  - blocked
+  - decided
+  - implemented
+  complete:
+  - complete
+  - done
+  - decided
+  - implemented
+  unstarted:
+  - unstarted
+  - approved-and-unstarted


### PR DESCRIPTION
This PR renames the canonical agent-executable review status to needs-agent-review so it is not confused with needs-human-input.

Validation:
- just plan-validate from /home/dzack/research passed against these schemas
- git diff checks passed for planning schemas and renderer

Notes:
- The renderer keeps separate styling for needs-human-input.
- The research repo consumes these schemas through symlinks.